### PR TITLE
Fix for Meteor 1.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'underscore',
   summary: "Collection of small helpers: _.map, _.each, ...",
-  version: '1.0.4-rc.0'
+  version: '1.0.4'
 });
 
 Npm.depends({'lodash': '3.7.0'});

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'underscore',
   summary: "Collection of small helpers: _.map, _.each, ...",
-  version: '1.0.3'
+  version: '1.0.4-rc.0'
 });
 
 Npm.depends({'lodash': '3.7.0'});


### PR DESCRIPTION
You need to upgrade underscore to 0.14-rc.0 if you are using Meteor 1.2. I guess this should not be merged until Meteor 1.2 is an official release.
